### PR TITLE
Bugfix for plotting with rules-based model

### DIFF
--- a/R/runModels.R
+++ b/R/runModels.R
@@ -195,6 +195,11 @@ getResultsDecisionTree <- function(inputs, config) {
   the.model.rpart <- if(inputs$XDFInfo$is_XDF) the.report.list$model_rpart else the.model
   the.report <- the.report.list$out
 
+  if(config$model.algorithm == "C5.0" && config$rules){
+    config$tree.plot <- FALSE
+    AlteryxMessage2("Tree Plot not available for C5.0 when rules-based model is chosen")
+  }
+
   makeTreePlot <- NULL
   makePrunePlot <- NULL
 

--- a/R/runModels.R
+++ b/R/runModels.R
@@ -195,8 +195,15 @@ getResultsDecisionTree <- function(inputs, config) {
   the.model.rpart <- if(inputs$XDFInfo$is_XDF) the.report.list$model_rpart else the.model
   the.report <- the.report.list$out
 
-  makeTreePlot <- function(){createTreePlotDT(the.model.rpart, config, inputs)}
-  makePrunePlot <- function(){createPrunePlotDT(the.model.rpart)}
+  makeTreePlot <- NULL
+  makePrunePlot <- NULL
+
+  if(config$tree.plot) {
+    makeTreePlot <- function(){createTreePlotDT(the.model.rpart, config, inputs)}
+  }
+  if(config$prune.plot) {
+    makePrunePlot <- function(){createPrunePlotDT(the.model.rpart)}
+  }
   dashboard <- createDashboardDT(the.model)
 
   results <- list(model = the.model, report = the.report,

--- a/tests/testthat/test-integration-decision-tree.R
+++ b/tests/testthat/test-integration-decision-tree.R
@@ -64,3 +64,12 @@ comment = 'This workflow tests that admission data with logit link returns corre
 #   ),
 #   outFile = file.path(testDir, "LogisticTest1.yxmd")
 # )
+
+config$rules <- TRUE
+
+exp_C50_model <- C50::C5.0(formula = Species ~ ., data = iris, rule = TRUE)
+
+test_that("Iris data with C5.0 rules model", {
+  result <- AlteryxPredictive:::getResultsDecisionTree(inputs, config)
+  expect_equal(result$model$tree, exp_C50_model$tree)
+})


### PR DESCRIPTION
Stops tree plot from attempting to generate for C5.0 rules-based model. 

Also, fixes backend handling of tree and prune plot options.