### PR TITLE
write out empty plots to fill metainfo.

### DIFF
--- a/R/runModels.R
+++ b/R/runModels.R
@@ -16,6 +16,9 @@ writeOutputs.GLM <- function(results, config){
   # Model Object
   the.obj <- prepModelForOutput(config$`Model Name`, results$model)
   write.Alteryx2(the.obj, nOutput = 3)
+  # Write out empty plots so MetaInfo is filled out.
+  AlteryxGraph2(emptyPlot(), nOutput = 4)
+  AlteryxGraph2(emptyPlot(), nOutput = 5)
 }
 
 

--- a/R/runModels.R
+++ b/R/runModels.R
@@ -13,12 +13,13 @@ writeOutputs.GLM <- function(results, config){
   AlteryxGraph2(results$plot(), 2, width = whr[1], height = whr[2],
     res = whr[3], pointsize = 9)
 
-  # Model Object
-  the.obj <- prepModelForOutput(config$`Model Name`, results$model)
-  write.Alteryx2(the.obj, nOutput = 3)
   # Write out empty plots so MetaInfo is filled out.
   AlteryxGraph2(emptyPlot(), nOutput = 4)
   AlteryxGraph2(emptyPlot(), nOutput = 5)
+
+  # Model Object
+  the.obj <- prepModelForOutput(config$`Model Name`, results$model)
+  write.Alteryx2(the.obj, nOutput = 3)
 }
 
 

--- a/R/runModels.R
+++ b/R/runModels.R
@@ -60,7 +60,7 @@ writeOutputs.DecisionTree <- function(results, config) {
     )
   } else if (!(config$`display.static`)) {
     #Write out garbage data that will get filtered out on the Alteryx side
-    AlteryxGraph2(plot(x = 1, y = 1), nOutput = 2)
+    AlteryxGraph2(emptyPlot(), nOutput = 2)
   }
 
   # Model Object
@@ -76,9 +76,9 @@ writeOutputs.DecisionTree <- function(results, config) {
     AlteryxGraph2(results$prunePlot(), nOutput = 4, width = whr[1], height = whr[2],
                   res = whr[3], pointsize = config$prune.pointsize
     )
-  } else if (!(config$`display.static`)) {
+  } else {
     #Write out garbage data that will get filtered out on the Alteryx side
-    AlteryxGraph2(plot(x = 1, y = 1), nOutput = 4)
+    AlteryxGraph2(emptyPlot(), nOutput = 4)
   }
   # Interactive Dashboard
   flightdeck::fdRender(x = results$dashboard, nOutput = 5)


### PR DESCRIPTION
This PR writes out empty plots for  Outputs 4 and 5 when Regularization is set to `FALSE`. This allows MetaInfo to be written out for these outputs, thereby preventing the infamous ugly red mark on opening a workflow.

There are only two cardinal rules to follow with R tools to avoid MetaInfo issues:

1. The R tool should always write all outputs no matter how the macro is configured
2. The R tool should always write outputs with field names that stay unchanged no matter how the macro is configured.

While this may seem impossible to achieve at first glance, there are tricks that allow one to satisfy both (1) and (2).

The first rule can always be satisfied by writing out empty plots or data. If they affect anything downstream, you can always use Alteryx tools to filter or strip things out. Alteryx tools handle metainfo updates a lot better and so you are always better of relegating that to Alteryx tools.

The second rule seems unattainable since there are several use cases where outputs coming out of the R tool need to have dynamic field names. Here again, there are two tricks one can use:

1. When the number of fields are fixed, use placeholder field names for outputs created by the R tool and use a Dynamic Rename downstream to update them to what they should be.

2. When the number of fields in an output is dynamic, consider rewriting the logic to produce long data with fixed number of columns instead of wide data. Use the CrossTab tool downstream to coerce the data back to the desired structure. 