### PR TITLE
Rv/bugfix/dynamic title widths

### DIFF
--- a/R/interactiveLMReport.R
+++ b/R/interactiveLMReport.R
@@ -477,14 +477,17 @@ interactive_lm_report <- function(
     ),
     third_menu_item
   )
-
+  titleWidth <- computeWidth(the_title)
   fdBoard(
     fdHeader(
       title = the_title,
-      titleWidth = 600),
-    fdSidebar(the_sidebar),
+      titleWidth = titleWidth
+    ),
+    fdSidebar(
+      the_sidebar,
+      sidebarWidth = titleWidth
+    ),
     the_body,
     fixed = TRUE
   )
-
 }

--- a/R/interactive_DT.R
+++ b/R/interactive_DT.R
@@ -390,11 +390,16 @@ interactive_dt <- function(
       )
     }
   }
+  titleWidth <- computeWidth(title)
   fdBoard(
     fdHeader(
       title = title,
-      titleWidth = 600),
-    fdSidebar(sidebar),
+      titleWidth = titleWidth
+    ),
+    fdSidebar(
+      sidebar,
+      sidebarWidth = titleWidth
+    ),
     body,
     fixed = TRUE
   )

--- a/R/interactive_lr.R
+++ b/R/interactive_lr.R
@@ -382,13 +382,17 @@ interactive_lr <- function(
     page_2,
     page_3
   )
+  titleWidth <- computeWidth(title)
   fdBoard(
     fdHeader(
       title = title,
-      titleWidth = 600),
-    fdSidebar(sidebar),
+      titleWidth = titleWidth
+    ),
+    fdSidebar(
+      sidebar,
+      sidebarWidth = titleWidth
+    ),
     body,
     fixed = TRUE
   )
-
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -69,3 +69,7 @@ emptyPlot <- function(){
     xlab = "", ylab = "", xaxt = "n", yaxt = "n"
   )
 }
+
+computeWidth <- function(title, cex = 1.5, dpi = 96){
+  strwidth(title, cex = cex, units = 'in')*dpi
+}


### PR DESCRIPTION
This PR computes the dashboard title and sidebar widths dynamically. It is an approximation that uses the `strwidth` function in R and implements a `computeWidth` function. We might need a few tweaks to the constants passed on to `computeWidth` to get this perfect.